### PR TITLE
version 0.0.2

### DIFF
--- a/fastapi_auth/__init__.py
+++ b/fastapi_auth/__init__.py
@@ -1,3 +1,3 @@
 from fastapi_auth.fastapi_auth import FastApiAuth
 
-__version__ = "0.0.1"
+__version__ = "0.0.2"


### PR DESCRIPTION
Fixed serializer f-string issue, when serializer.response.model() tried to create name for model python 3.11 <